### PR TITLE
Fixed: Add stub for client behaviors document

### DIFF
--- a/client-behaviors.html
+++ b/client-behaviors.html
@@ -119,7 +119,8 @@
 <section id="abstract" class="informative">
     <h2>Introduction</h2>
     <p>
-        This document provides guidance to OCFL implementers for how clients should behave when operating on OCFL Objects.
+        This document provides guidance to OCFL implementers for how clients should behave when operating on
+        OCFL Objects.
     </p>
 </section>
 </body>

--- a/client-behaviors.html
+++ b/client-behaviors.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Client Behaviours, Oxford Common File Layout Specification</title>
+    <meta charset="utf-8">
+    <meta name="description" content="Client Behaviours, Oxford Common File Layout Specification">
+    <script src="./respec-w3c-common.js"
+            async class="remove"></script>
+    <script class="remove">
+        var respecConfig = {
+            specStatus: "unofficial",
+            shortName: "ocfl-spec",
+            includePermalinks: true,
+            editors: [
+                {
+                    name: "Andrew Hankinson",
+                    company: "Bodleian Libraries, University of Oxford",
+                    companyURL: "http://www.bodleian.ox.ac.uk/"
+                },
+                {
+                    name: "Neil Jefferies",
+                    company: "Bodleian Libraries, University of Oxford",
+                    companyURL: "http://www.bodleian.ox.ac.uk/"
+                },
+                {
+                    name: "Rosalyn Metz",
+                    company: "Emory University",
+                    companyURL: "https://web.library.emory.edu/"
+                },
+                {
+                    name: "Julian Morley",
+                    company: "Stanford University",
+                    companyURL: "https://library.stanford.edu/"
+                },
+                {
+                    name: "Simeon Warner",
+                    url: "https://orcid.org/0000-0002-7970-7855",
+                    company: "Cornell University",
+                    companyURL: "https://www.library.cornell.edu/"
+                },
+                {
+                    name: "Andrew Woods",
+                    company: "DuraSpace",
+                    companyURL: "http://duraspace.org/"
+                }
+            ],
+            edDraftURI: "https://ocfl.io",
+            wg: "Oxford Common File Layout Editors",
+            wgURI: "https://ocfl.io",
+            wgPublicList: "",
+            otherLinks: [{
+                key: "Previous version",
+                data: [
+                    {
+                        value: "N/A"
+                    }
+                ]
+            }, {
+                key: "Repository",
+                data: [
+                    {
+                        value: "Github",
+                        href: "https://github.com/ocfl/spec"
+                    },
+                    {
+                        value: "Issues",
+                        href: "https://github.com/ocfl/spec/issues"
+                    },
+                    {
+                        value: "Commits",
+                        href: "https://github.com/ocfl/spec/commits"
+                    },
+                    {
+                        value: "Use Cases",
+                        href: "https://github.com/ocfl/Use-Cases"
+                    }
+                ]
+            }],
+            maxTocLevel: 3,
+            logos: [{
+                src: "https://avatars0.githubusercontent.com/u/35607965",
+                alt: "OCFL Logo",
+                width: 307,
+                height: 307
+            }],
+            overrideCopyright: '<p class="copyright">This document is licensed under a ' +
+                '<a class="subfoot" href="https://creativecommons.org/licenses/by/4.0/" rel="license">' +
+                'Creative Commons Attribution 4.0 License</a>.</p>',
+            localBiblio: {
+                "NAMASTE": {
+                    title: "Directory Description with Namaste Tags",
+                    href: "https://confluence.ucop.edu/download/attachments/14254149/NamasteSpec.pdf",
+                    authors: [
+                        "J. Kunze"
+                    ],
+                    date: "9 November 2009"
+                },
+                "JSON-LD-1.1": {
+                    title: "JSON-LD 1.1: A JSON-based Serialization for Linked Data",
+                    href: "https://json-ld.org/spec/latest/json-ld/",
+                    authors: [
+                        "Manu Sporny", "Dave Longley", "Gregg Kellogg", "Markus Lanthaler", "Niklas Lindström"
+                    ],
+                    date: "7 June 2018"
+                }
+            }
+        };
+    </script>
+    <style>
+        em.rfc2119 {
+            text-transform: lowercase;
+            font-variant: small-caps;
+            font-style: normal;
+            color: #900;
+        }
+    </style>
+</head>
+<body>
+<section id="abstract" class="informative">
+    <h2>Introduction</h2>
+    <p>
+        This document provides guidance to OCFL implementers for how clients should behave when operating on OCFL Objects.
+    </p>
+</section>
+</body>
+</html>


### PR DESCRIPTION
This commit adds a stub document for writing the client behaviors for OCFL.

Fixes #66 