### PR TITLE
Wording tweaks in digest section

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -324,7 +324,7 @@
             Digests play two roles in an OCFL Object. The first is that digests allow for content-addressable
             storage; that is, for a file to be addressed by the digest of its contents, rather than its filename.
             The second is that digests provide for fixity checks to determine whether a file has become corrupt
-            through hardware degradation, accident or malicious actors.
+            through hardware degradation, accident, or malicious actors.
         </p>
         <p>
             OCFL Objects SHOULD use <code>sha512</code> by default. The choice of <code>sha512</code> recognizes


### PR DESCRIPTION
- causes of fixity error omitted "accident" -- the most likely one
- longer digests don't just reduce the likelihood of known digest collisions, they also reduce the likelihood of so far unknown ones!
- comma for clarity