### PR TITLE
Add manifest section

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -409,6 +409,30 @@
 
         <section id="manifest">
             <h2>Manifest</h2>
+            <p>
+                The value of the <code>manifest</code> key is a JSON object, with keys corresponding to the digests
+                of every content file in all versions of the <a>OCFL Object</a>. The value for each key is an array
+                containing the <a>logical file path</a>s of files in the OCFL Object that have content with the
+                given digest.
+            </p>
+            <blockquote class="informative">
+                <p>
+                    Non-normative note: If only one file is stored in the OCFL Object for each digest, fully
+                    de-duplicating the content, then there will be only one logical file path for each digest.
+                    There may, however, be multiple logical file paths for a given digest if the content was
+                    not entirely de-duplicated when constructing the OCFL Object.
+                </p>
+                <p>
+                    An example manifest object for three logical file paths, all in version 1, is shown below:
+                </p>
+<pre>
+"manifest": {
+    "7dcc35...c31": [ "v1/metadata/foo.xml" ],
+    "cf83e1...a3e": [ "v1/empty.txt" ],
+    "ffccf6...62e": [ "v1/image.tiff" ]
+}
+</pre>
+            </blockquote>
         </section>
 
         <section id="versions">


### PR DESCRIPTION
Add a first stab at manifest section.

(example data is consistent with `state` and `fixity` sections, from https://github.com/zimeon/ocfl-fixtures/tree/master/content/spec-ex )