### PR TITLE
Fixed: Updated json-ld context

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -388,7 +388,7 @@
             An OCFL Object Inventory MUST follow the [[!JSON]] structure described in this section and MUST be named
             <code>inventory.jsonld</code>. Furthermore, inventory files MUST conform to [[!JSON-LD-1.1]], MUST include
             the JSON-LD <code>@context</code> value
-            <a href="context.jsonld"><code>https://ocfl.io/context.jsonld</code></a>.
+            <a href="https://ocfl.io/draft/context.jsonld"><code>https://ocfl.io/draft/context.jsonld</code></a>.
         </p>
         <blockquote class="informative">
             Non-normative note: The use of JSON-LD for inventory files means that they can be generated from and


### PR DESCRIPTION
This is a quick non-normative change to update the address to the JSON LD context. I included the full
URL, rather than a relative URL, to make it easier to find and change at release.