### PR TITLE
Fix draft links

### DIFF
--- a/draft/implementation-notes/index.html
+++ b/draft/implementation-notes/index.html
@@ -44,7 +44,7 @@
                     companyURL: "http://duraspace.org/"
                 }
             ],
-            edDraftURI: "https://ocfl.io",
+            edDraftURI: "https://ocfl.io/draft/implementation-notes/",
             wg: "Oxford Common File Layout Editors",
             wgURI: "https://ocfl.io",
             wgPublicList: "",

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -44,7 +44,7 @@
                     companyURL: "http://duraspace.org/"
                 }
             ],
-            edDraftURI: "https://ocfl.io",
+            edDraftURI: "https://ocfl.io/draft/spec/",
             wg: "Oxford Common File Layout Editors",
             wgURI: "https://ocfl.io",
             wgPublicList: "",


### PR DESCRIPTION
Fix "Latest editor's draft:" link for both spec and implementation notes