### PR TITLE
Editorial pass and add OAIS link to implementation notes

### DIFF
--- a/draft/implementation-notes/index.html
+++ b/draft/implementation-notes/index.html
@@ -95,6 +95,11 @@
                     ],
                     date: "9 November 2009"
                 },
+                "OAIS": {
+                    title: " Reference Model for an Open Archival Information System (OAIS), Issue 2",
+                    href: "https://public.ccsds.org/pubs/650x0m2.pdf",
+                    date: "June 2012"
+                },
                 "JSON-LD-1.1": {
                     title: "JSON-LD 1.1: A JSON-based Serialization for Linked Data",
                     href: "https://json-ld.org/spec/latest/json-ld/",
@@ -129,7 +134,7 @@
 <p>
 A key goal of OCFL is the rebuildability of a repository from an OCFL storage root without additional information
 resources. Consequently, a key implementation consideration should be to ensure that OCFL objects contain all the
-data and metadata required to achieve this. With reference to th OAIS model, this would include all the
+data and metadata required to achieve this. With reference to the [[OAIS]] model, this would include all the
 descriptive, administrative, structural, representation and preservation metadata relevant to the object.
 </p>
 </section><section>
@@ -137,153 +142,154 @@ descriptive, administrative, structural, representation and preservation metadat
 <h2>Filesystem metadata</h2>
 <p>
 Filesystem metadata (e.g. permissions, access and creation times) are not considered portable between filesystems
-or preservable through file transfer operrations. Nor can these attributes be vaidated in terms of fixity in a
-consistent manner. As such, OCFL neither explicitly supports nor expects that these quanties remain consistent. 
+or preservable through file transfer operations. Nor can these attributes be vaidated in terms of fixity in a
+consistent manner. As such, OCFL neither explicitly supports nor expects that these quanties remain consistent.
 If retaining this metadata is important then files should either be encapsulated in a filesystem image format that
 preserves this information, or the metadata extracted and stored explicitly in an additional file.
-</p> 
+</p>
 </section><section>
 
 <h2>Empty Directories</h2>
 <p>
-OCFL preserves files and their content with directories serving as a useful organisational convention. An empty 
-directory consists only of filesystem metadata and therefore, as noted above, is not amenable to direct 
-preservation in OCFL. If the preservation of empty directories is considered essential then the suggested route 
-is to insert a zero length file named <code>.keep</code> into the directory which will thus be preserved as 
+OCFL preserves files and their content, with directories serving as a useful organisational convention. An empty
+directory consists only of filesystem metadata and therefore, as noted above, is not amenable to direct
+preservation in OCFL. If the preservation of empty directories is considered essential then the suggested route
+is to insert a zero length file named <code>.keep</code> into the directory which will thus be preserved as
 part of the files' path.
 </p>
 </section><section>
 
 <h2>Data and Metadata</h2>
 <p>
-OCFL object versions are composed of series of files/bitstreams but OCFL does not make any disctinction between 
-different types of files other than those reserved for OCFL functionality: the inventory and its digest file. 
-It is possible, for example, to create separate data and metadata directories within each version to help 
+OCFL object versions are composed of series of files/bitstreams but OCFL does not make any disctinction between
+different types of files other than those reserved for OCFL functionality: the inventory and its digest file.
+It is possible, for example, to create separate data and metadata directories within each version to help
 organise material but all files are treated equally for the purpose of OCFL validation and management.
 </p>
 </section><section>
 
 <h2>Physical storage</h2>
 <p>
-OCFL separates the paths of physical stored files from the logical location of these files' content in OCFL 
-object versions. This is a key feature that allows previous versions of objects to remain immutable but 
-permitting deduplication, forward delta differencing and easy file renaming. Consequently, OCFL only requires 
-that files added to any version of an OCFL object must be stored somewhere within the relevant version 
-directory, with a corresponding entry in the manifest block. An entry in the state block determines the path 
-and name of the file within that version by reference to the manifest entry, not the actual path on disk.      
+OCFL separates the paths of physical stored files from the logical location of these files' content in OCFL
+object versions. This is a key feature that allows previous versions of objects to remain immutable but
+permitting deduplication, forward delta differencing, and easy file renaming. Consequently, OCFL only requires
+that files added to any version of an OCFL object must be stored somewhere within the relevant version
+directory, with a corresponding entry in the manifest block. An entry in the state block determines the path
+and name of the file within that version by reference to the manifest entry, not the actual path on disk.
 </p><p>
-The most transparent approach is to have the path used to store the file on disk the same as the path of the 
-file within the object when accessioned. This is readily understandable in terms of visual inspection of the 
+The most transparent approach is to have the path used to store the file on disk the same as the path of the
+file within the object when accessioned. This is readily understandable in terms of visual inspection of the
 physical filesystem.
 </p><p>
-However, this is not always possible. For example, complex objects with deep file hierarchies may encounter 
-issues if they come a from fileystem that allows onger paths than are supported by the target OCFL system. In 
-this case, the decoupling between physical and logical file paths in OCFL allows the use of truncated paths 
+However, this is not always possible. For example, complex objects with deep file hierarchies may encounter
+issues if they come a from fileystem that allows onger paths than are supported by the target OCFL system. In
+this case, the decoupling between physical and logical file paths in OCFL allows the use of truncated paths
 for storage while the full paths can be preserved in state block entries which are not length constrained.
 </p><p>
-Another use case is importing content from other repository systems which renames file on ingest and stores 
+Another use case is importing content from other repository systems which renames file on ingest and stores
 them in a flat hierarchy. These can be imported, as is, and the original paths and file names recorded through
-suitable state block entries rather than reconstructing a physical file layout. Of course, OCFL supports 
-ongoing use of such a methodology.    
+suitable state block entries rather than reconstructing a physical file layout. Of course, OCFL supports
+ongoing use of such a methodology.
 </p>
 </section><section>
 
 <h2>Version Immutability</h2>
 <p>
-Previous versions of an object should be considered immutable since the composition of later versions of an 
-object may be dependent on them. In addition, the assumtion of immutability ensures that copies of different 
-versions of an object remain cosistent with each other, avoiding issues with identifying canonicity and 
-reconcilitation.     
+Previous versions of an object should be considered immutable since the composition of later versions of an
+object may be dependent on them. In addition, the assumtion of immutability ensures that copies of different
+versions of an object remain cosistent with each other, avoiding issues with identifying canonicity and
+reconcilitation.
 </p><p>
-One key consequence of this immutabilty is that manifest entries should never be deleted. New entries may be 
+One key consequence of this immutabilty is that manifest entries should never be deleted. New entries may be
 created, and, if not deduplicating file content, additional references to copies of stored content may be added.
 </p>
 </section><section>
 
 <h2>Deduplication</h2>
 <p>
-OCFL supports optional deduplication if a client ensures that all digests in the manifest block refer to a 
+OCFL supports optional deduplication if a client ensures that all digests in the manifest block refer to a
 single file path on disk. This entry is created the first time particular file content is stored in an object.
 Subsequent references to that file content should then occur in the state block only. This can be determined by
-computing the digests of incoming files and determining if they already exist in the manifest block. If 
-deduplication is carried out within an object then, for consistency, it is expected that Forward Delta 
-deduplication will also be used between object versions so subsequent references to duplicated content should 
-also refer back to the original manifest entry rather than updating it to include additional references.     
+computing the digests of incoming files and determining if they already exist in the manifest block. If
+deduplication is carried out within an object then, for consistency, it is expected that Forward Delta
+deduplication will also be used between object versions so subsequent references to duplicated content should
+also refer back to the original manifest entry rather than updating it to include additional references.
 </p>
 </section><section>
 
 <h2>Forward Delta</h2>
 <p>
-Forward delta differencing is a key, though optional, feature of OCFL that means that parts of an OCFL object 
-version that are unchanged from a previous version are not stored again. This has the potential to signficantly 
-improve storage efficiency when objects have multiple versions, whether through ongoing curatorial action or 
-the accessioning of updated material. 
+Forward delta differencing is a key, though optional, feature of OCFL that means that parts of an OCFL object
+version that are unchanged from a previous version are not stored again. This has the potential to signficantly
+improve storage efficiency when objects have multiple versions, whether through ongoing curatorial action or
+the accessioning of updated material.
 </p><p>
-When a new version of an OCFL Object is created from an earlier version and a client wishes to implement forward 
+When a new version of an OCFL Object is created from an earlier version and a client wishes to implement forward
 delta differencing, then the possible file operations are handled in the following manner:
 </p>
 <ul>
-<li>File inherited from the previous version unchanged are referenced in the state block of the new version. 
-These entries will be indentical to the corresponding entries in the previous version's state object.</li> 
-<li>Files renamed from the previous version are referenced in the state block of the new version. The state 
+<li>File inherited from the previous version unchanged are referenced in the state block of the new version.
+These entries will be indentical to the corresponding entries in the previous version's state object.</li>
+<li>Files renamed from the previous version are referenced in the state block of the new version. The state
 block entry with the name still points to the same manifest entry.</li>
-<li>Files updated from the previous version are referenced in the state block of the new version. If the file 
-content, as determined by its digest, corresponds to an existing manifest entry then the state block should 
-point to it (it is possible that the updated file has the same content as a file other than the original). 
-Otherwise, the file should be stored and s new entry for the updated content must be made in the manifest 
+<li>Files updated from the previous version are referenced in the state block of the new version. If the file
+content, as determined by its digest, corresponds to an existing manifest entry then the state block should
+point to it (it is possible that the updated file has the same content as a file other than the original).
+Otherwise, the file should be stored and a new entry for the updated content must be made in the manifest
 block of the object.</li>
 <li>Files deleted from the previous version are simply not included in the state block of the new version.</li>
-<li>File re-instated from earlier versions are referenced in the state block of the new version. These entries 
-will be indentical to the corresponding entries in the earlier version's state object.</li>  
-<li>New files added are referenced in the state block of the new version. If the file content, as determined 
+<li>File re-instated from earlier versions are referenced in the state block of the new version. These entries
+will be indentical to the corresponding entries in the earlier version's state object.</li>
+<li>New files added are referenced in the state block of the new version. If the file content, as determined
 by its digest, corresponds to an existing manifest entry then the state block should point to it. Otherwise, the
-file should be stored and s new entry for the updated content must be made in the manifest block of the object.</li>
+file should be stored and a new entry for the updated content must be made in the manifest block of the object.</li>
 </ul>
 </section><section>
 
 <h2>Fixity</h2>
 <p>
-The digests in the manifest are used by OCFL for content addressability rather than fixity but they are 
-suitable for use as part of a fixity regime, and the manifest usefully identifies all the files in an object. 
-Additional fixity entries may be made in the fixity block which permits a broader range of algorithms but has 
-the same layout as a manifest block. OCFL will consider the fixity block valid provided that the files 
-referenced in the block exist but OCFL cannot, reasonably, validate the hashes themselves. The fixity block 
-does not have to include all the files in an object to permit legacy fixity to be imported without requiring 
+The digests in the manifest are used by OCFL for content addressability rather than fixity but they are
+suitable for use as part of a fixity regime, and the manifest usefully identifies all the files in an object.
+Additional fixity entries may be made in the fixity block which permits a broader range of algorithms but has
+the same layout as a manifest block. OCFL will consider the fixity block valid provided that the files
+referenced in the block exist but OCFL cannot, reasonably, validate the hashes themselves. The fixity block
+does not have to include all the files in an object to permit legacy fixity to be imported without requiring
 continued use of obsolete digest algorithms.
 </p>
 </section><section>
 
 <h2>File Purging</h2>
 <p>
-Dometimes a file needs to be deleted from all versons of an object, perhaps for legal reasons. Doing this to
+Sometimes a file needs to be deleted from all versons of an object, perhaps for legal reasons. Doing this to
 an OCFL object breaks the previous version immutability assumption and is not supported directly. The correct
 way to do this is to create a new object the excludes the offending file with a revised version history taking
-this into account. The original object can then be deleted in its entirety - creating the new object first is 
-good practice to avoid any risk of data loss. The new object will be unlikely to have the same identifer as 
+this into account. The original object can then be deleted in its entirety &#x2014; creating the new object first is
+good practice to avoid any risk of data loss. The new object will be unlikely to have the same identifer as
 the orignal object so the deleted object can be replaced by a stub object that directs users and software to the
-new version.     
+new version.
 </p>
 </section><section>
 
 <h2>Log Information</h2>
 <p>
-There may be the need to record some actions on objects that do not result in changes to the object content. 
-For example, copying the object to new storage or validating fixity and finding nothing amiss. The Log 
-directory is the location in an OCFL object where such events can be recorded. OCFL does not make any assumptions 
+There may be the need to record some actions on objects that do not result in changes to the object content.
+For example, copying the object to new storage or validating fixity and finding nothing amiss. The <code>log</code>
+directory is the location in an OCFL object where such events can be recorded. OCFL does not make any assumptions
 about the contents of this directory but, if it exists, then its contents will not be subject any validation
-processes. 
+processes.
 </p>
 </section><section>
 
 <h2>Version Numbering</h2>
 <p>
-Version numbering should start with 1 and be positive sequential integers. Names start with a lover case "v" and 
-the numbers may be zero padded to the left to give give fixed length, but, if used, zero padded numbers must 
-always retain at least one leftmost zero. All versions in an object must use the same version numbering layout 
-which can be easily determined by looking at one existing verion - if the digit following "v" is a zero then 
-the number format is zero padded to fixed length, otherwise it is simply an integer.  
+Version numbering should start with 1 and be positive sequential integers. Names start with a lower case
+<code>v</code>. The numbers may be zero padded to the left to give fixed length, but, if used, zero padded
+numbers must always retain at least one leftmost zero. All versions in an object must use the same version
+numbering layout which can be easily determined by looking at one existing verion &#x2014; if the digit
+following <code>v</code> is a zero then the number format is zero padded to fixed length, otherwise it
+is simply an integer.
 </p>
 </section>
-     
+
 </body>
 </html>


### PR DESCRIPTION
I did a very light editorial pass on the implementation notes (fixed some typos, add a couple of commas, remove some line ending spaces, a little code font), and added an OAIS link. No changes to meaning.