### PR TITLE
Change ID to identifier

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -428,7 +428,7 @@
                 </dd>
                 <dt><code>id</code></dt>
                 <dd>
-                    A unique ID for the OCFL Object. This MUST be unique in the local context, and SHOULD be either a
+                    A unique identifier for the OCFL Object. This MUST be unique in the local context, and SHOULD be either a
                     URI or URN. There is no expectation that values given as URIs are resolveable as URLs.
                 </dd>
                 <dt><code>type</code></dt>
@@ -443,7 +443,7 @@
                 </dd>
                 <dt><code>head</code></dt>
                 <dd>
-                    A value corresponding to the ID of the most recent, or 'head,' version of the object.
+                    A value corresponding to the identifier of the most recent, or 'head,' version of the object.
                 </dd>
             </dl>
             <p>

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -428,8 +428,8 @@
                 </dd>
                 <dt><code>id</code></dt>
                 <dd>
-                    A unique identifier for the OCFL Object. This MUST be unique in the local context, and SHOULD be either a
-                    URI or URN. There is no expectation that values given as URIs are resolveable as URLs.
+                    A unique identifier for the OCFL Object. This MUST be unique in the local context, and SHOULD be
+                    either a URI or URN. There is no expectation that values given as URIs are resolveable as URLs.
                 </dd>
                 <dt><code>type</code></dt>
                 <dd>


### PR DESCRIPTION
Just changing "ID" to "identifier" in two places, keeping with plain English where reasonable, and reducing the possibility of confusion with a possible technical meaning.