### PR TITLE
Remove references to physical storage

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -258,7 +258,7 @@
             (i.e., structure).</li>
     </ol>
     <p>
-        A key goal of OCFL is the rebuildability of a repository from an OCFL storage root without additional
+        A key goal of OCFL is the rebuildability of a repository from an OCFL Storage Root without additional
         information resources. Consequently, a key implementation consideration should be to ensure that OCFL Objects
         contain all the data and metadata required to achieve this. With reference to the [[OAIS]] model, this would
         include all the descriptive, administrative, structural, representation and preservation metadata relevant
@@ -268,7 +268,7 @@
     <section id="basic-structure">
         <h2>Basic Structure</h2>
         <p>
-            The basic OCFL Object structure has a minimal set of files and directories necessary to support data
+            The basic OCFL Object structure has a minimal set of files and directories necessary to support content
             storage and object validation. The minimum required is shown in the following figure:
         </p>
         <pre>


### PR DESCRIPTION
fixes #130 

note that i didn't find many instances of us referring to physical storage in the spec and none in the implementation notes.  That being said, I did find reference to data storage which seemed appropriate to replace with content storage.  Debate welcomed.