### PR TITLE
Make PairTree ref non-normative

### DIFF
--- a/draft/implementation-notes/index.html
+++ b/draft/implementation-notes/index.html
@@ -271,7 +271,7 @@
                   </pre>
               </li>
               <li>
-                  PairTree: [[!PairTree]] is designed to overcome the limitations on the number of files in a
+                  PairTree: [[PairTree]] is designed to overcome the limitations on the number of files in a
                   directory that most file systems have. It creates hierarchy of directories by mapping identifier
                   strings to directory paths two characters at a time. For numerical identifiers specified in
                   hexadecimal this means that there are a maximum of 256 items in any directory which is well


### PR DESCRIPTION
Can't have normative ref in implementation notes