### PR TITLE
Fixed: Specify that EFPs must be relative to OR.

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -513,11 +513,8 @@
                 The value of the <code>manifest</code> key is a JSON object, with keys corresponding to the digests
                 of every content file in all versions of the <a>OCFL Object</a>. The value for each key is an array
                 containing the <a>existing file path</a>s of files in the OCFL Object that have content with the
-                given digest.
-            </p>
-            <p>
-                <a data-lt="existing file path">Existing file paths</a> within a manifest block MUST be given relative
-                to the <a>OCFL Object Root</a>.
+                given digest. <a data-lt="existing file path">Existing file paths</a> within a manifest block MUST be
+                given relative to the <a>OCFL Object Root</a>.
             </p>
             <blockquote class="informative">
                 <p>

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -514,7 +514,7 @@
                 of every content file in all versions of the <a>OCFL Object</a>. The value for each key is an array
                 containing the <a>existing file path</a>s of files in the OCFL Object that have content with the
                 given digest. <a data-lt="existing file path">Existing file paths</a> within a manifest block MUST be
-                given relative to the <a>OCFL Object Root</a>.
+                relative to the <a>OCFL Object Root</a>.
             </p>
             <blockquote class="informative">
                 <p>

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -515,6 +515,10 @@
                 containing the <a>logical file path</a>s of files in the OCFL Object that have content with the
                 given digest.
             </p>
+            <p>
+                <a data-lt="existing file path">Existing file paths</a> within a manifest block MUST be given relative
+                to the <a>OCFL Object Root</a>.
+            </p>
             <blockquote class="informative">
                 <p>
                     Non-normative note: If only one file is stored in the OCFL Object for each digest, fully


### PR DESCRIPTION
This PR specifies that existing file paths MUST be given relative to the Object Root.