### PR TITLE
JSON schema for 0.1

### DIFF
--- a/0.1/spec/inventory_schema.json
+++ b/0.1/spec/inventory_schema.json
@@ -34,44 +34,44 @@
             "enum": [ "Object" ]
         },
         "versions": {
-            "type" : "array",
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "created": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "$ref": "#/definitions/digests_to_files"
-                    },
-                    "type": {
-                        "description": "Seems that using `const` would be nicer but that doesn't seem to work with Python jsonschema",
-                        "enum": [ "Version" ]
-                    },
-                    "user": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                            "address": {
-                                "type": "string"
-                            },
-                            "name": {
-                                "type": "string"
-                            }
+            "description": "Each key is a version directory name with version objects as values",
+            "type" : "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^v\\d+$": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "created": {
+                            "type": "string",
+                            "format": "date-time"
                         },
-                        "required": [ "address", "name" ]
+                        "message": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/digests_to_files"
+                        },
+                        "type": {
+                            "description": "Seems that using `const` would be nicer but that doesn't seem to work with Python jsonschema",
+                            "enum": [ "Version" ]
+                        },
+                        "user": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "address": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [ "address", "name" ]
+                        }
                     },
-                    "version": {
-                        "$ref": "#/definitions/version_directory"
-                    }
-                },
-                "required": [ "created", "message", "state", "type", "user", "version" ]
+                    "required": [ "created", "message", "state", "type", "user" ]
+                }
             }
         }
     },

--- a/draft/spec/inventory_schema.json
+++ b/draft/spec/inventory_schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://ocfl.io/draft/spec/inventory_schema.json",
+    "$id": "https://ocfl.io/0.1/spec/inventory_schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "JSON Schema for OCFL Inventory files",
     "description": "Note that this schema does not permit extension keys, only keys defined in the OCFL Specification are admitted.",
@@ -34,44 +34,44 @@
             "enum": [ "Object" ]
         },
         "versions": {
-            "type" : "array",
-            "uniqueItems": true,
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "created": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "message": {
-                        "type": "string"
-                    },
-                    "state": {
-                        "$ref": "#/definitions/digests_to_files"
-                    },
-                    "type": {
-                        "description": "Seems that using `const` would be nicer but that doesn't seem to work with Python jsonschema",
-                        "enum": [ "Version" ]
-                    },
-                    "user": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                            "address": {
-                                "type": "string"
-                            },
-                            "name": {
-                                "type": "string"
-                            }
+            "description": "Each key is a version directory name with version objects as values",
+            "type" : "object",
+            "additionalProperties": false,
+            "patternProperties": {
+                "^v\\d+$": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "created": {
+                            "type": "string",
+                            "format": "date-time"
                         },
-                        "required": [ "address", "name" ]
+                        "message": {
+                            "type": "string"
+                        },
+                        "state": {
+                            "$ref": "#/definitions/digests_to_files"
+                        },
+                        "type": {
+                            "description": "Seems that using `const` would be nicer but that doesn't seem to work with Python jsonschema",
+                            "enum": [ "Version" ]
+                        },
+                        "user": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "address": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [ "address", "name" ]
+                        }
                     },
-                    "version": {
-                        "$ref": "#/definitions/version_directory"
-                    }
-                },
-                "required": [ "created", "message", "state", "type", "user", "version" ]
+                    "required": [ "created", "message", "state", "type", "user" ]
+                }
             }
         }
     },


### PR DESCRIPTION
Update schema for the new inventory structure as part of #238 0.1 alpha release

See https://github.com/zimeon/ocfl-py/blob/master/README_inventory_validation.md for a way to build an example inventory and to run a test against the schema.