### PR TITLE
Remove 'v2' key in Simple Object JSON example

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -861,7 +861,6 @@
       "state": {
         "7545b8...f67": [ "file.txt" ]
       },
-    "v2": {
       "type": "Version",
       "user": {
         "address": "alice@example.org",


### PR DESCRIPTION
Previous request was made against what I think is the wrong version of the spec file. 