### PR TITLE
Clarify head must have the highest version directory name

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -535,7 +535,8 @@
                 </dd>
                 <dt><code>head</code></dt>
                 <dd>
-                    A value corresponding to the version directory name of the most recent version of the object.
+                    The version directory name of the most recent version of the object. This MUST be the version
+                    directory name with the highest version number.
                 </dd>
             </dl>
             <p>


### PR DESCRIPTION
Fixes #303 

As I wrote this it occurred to me that we should be explicit that the `head` must be the directory name with the highest version number. It is implied by "most recent" but seems best to be clear.