### PR TITLE
Fix release dates for 0.1 and 0.2

### DIFF
--- a/0.1/implementation-notes/index.html
+++ b/0.1/implementation-notes/index.html
@@ -8,6 +8,7 @@
             async class="remove"></script>
     <script class="remove">
         var respecConfig = {
+            publishDate: "2018-10-18",
             specStatus: "ocfl-cr",
             shortName: "ocfl-spec",
             includePermalinks: true,

--- a/0.1/spec/index.html
+++ b/0.1/spec/index.html
@@ -8,6 +8,7 @@
             async class="remove"></script>
     <script class="remove">
         var respecConfig = {
+            publishDate: "2018-10-18",
             specStatus: "ocfl-cr",
             shortName: "ocfl-spec",
             includePermalinks: true,

--- a/0.2/implementation-notes/index.html
+++ b/0.2/implementation-notes/index.html
@@ -8,6 +8,7 @@
             async class="remove"></script>
     <script class="remove">
         var respecConfig = {
+            publishDate: "2019-02-18",
             specStatus: "ocfl-cr",
             shortName: "ocfl-spec",
             includePermalinks: true,

--- a/0.2/spec/index.html
+++ b/0.2/spec/index.html
@@ -8,6 +8,7 @@
             async class="remove"></script>
     <script class="remove">
         var respecConfig = {
+            publishDate: "2019-02-18",
             specStatus: "ocfl-cr",
             shortName: "ocfl-spec",
             includePermalinks: true,


### PR DESCRIPTION
Without setting an explicit `publishDate` the respec formatter shows the mtime, which is updated for all files whenever there is new content in the repository!

Minor fix, no change to content.