### PR TITLE
Fix validation errors in json schema

### DIFF
--- a/draft/spec/inventory_schema.json
+++ b/draft/spec/inventory_schema.json
@@ -31,7 +31,7 @@
         },
         "type": {
             "description": "Seems that using `const` would be nicer but that doesn't seem to work with Python jsonschema",
-            "enum": [ "Object" ]
+            "enum": ["https://ocfl.io/1.0/spec/#inventory"]
         },
         "versions": {
             "description": "Each key is a version directory name with version objects as values",
@@ -52,10 +52,6 @@
                         "state": {
                             "$ref": "#/definitions/digests_to_files"
                         },
-                        "type": {
-                            "description": "Seems that using `const` would be nicer but that doesn't seem to work with Python jsonschema",
-                            "enum": [ "Version" ]
-                        },
                         "user": {
                             "type": "object",
                             "additionalProperties": false,
@@ -70,7 +66,7 @@
                             "required": [ "address", "name" ]
                         }
                     },
-                    "required": [ "created", "message", "state", "type", "user" ]
+                    "required": [ "created", "message", "state", "user" ]
                 }
             }
         }


### PR DESCRIPTION
Valid OCFL inventories do not validate against the inventory_schema.json
schema. This is for two reasons:

  - the inventory 'type' property is incorrectly defined as an object
  - in the schema, versions have a required property 'type' that is not
      in the spec

This update provides a schema for inventory.json that does validate
valid OCFL inventory schemas.

See https://github.com/OCFL/spec/issues/335