### PR TITLE
Fixed: Add note about object stores

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -178,6 +178,13 @@
       (the "object-in-motion") can be found in the [[OCFL-Implementation-Notes]]. The OCFL editorial group recommends
       reading both the specification and the implementation notes in order to understand the full scope of the OCFL.
   </p>
+    <p>
+        This specification is designed to operate on storage systems that employ a hierarchical metaphor for
+        presenting data to users. On traditional disk-based storage this may take the form of files and directories,
+        and this is the terminology we use in this specification since it is widely known. However, it may equally
+        apply to object stores, where namespaces, containers, and objects present a similar organization hierarchy to
+        users.
+    </p>
     <section id="need">
         <h2>Need</h2>
         <p>


### PR DESCRIPTION
Add a paragraph acknowledging the difference in terminology between filesystems and object stores.

Fixes #323