### PR TITLE
Add contentDirectory to schema

### DIFF
--- a/draft/spec/inventory_schema.json
+++ b/draft/spec/inventory_schema.json
@@ -71,6 +71,10 @@
                     "required": [ "created", "state" ]
                 }
             }
+        },
+        "contentDirectory": {
+            "type": "string",
+            "pattern": "^[^/]+$"
         }
     },
     "required": [ "digestAlgorithm", "head", "id", "manifest", "type", "versions" ],


### PR DESCRIPTION
* Adds `contentDirectory` as an allowable property to the inventory.json schema
* Restricts the value of `contentDirectory` to any string that does not contain a solidus (`/`) character

One oddity:  This PR is targeted towards the `draft/` directory, though the text defining `contentDirectory` seems to be in `0.2/` directory, which I _think_ was supposed to be immutable after its publication.  Let me know if this PR should be to `0.2/` instead.