### PR TITLE
Digest algorithms

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -515,7 +515,7 @@
             <tr>
                 <td><code>blake2b-512</code></td>
                 <td>Full-length form only, using the 2B variant (64 bit) as defined by [[!RFC7693]]. MUST be encoded
-                    using hex (base16) encoding [[!RFC4648]]. For example, the <code>blake2b</code> digest of a
+                    using hex (base16) encoding [[!RFC4648]]. For example, the <code>blake2b-512</code> digest of a
                     zero-length bitstream starts <code>786a02f742015903c6c6fd852552d272912f4740...</code> (128 hex
                     digits long).</td>
             </tr>

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -513,7 +513,7 @@
                     <code>cf83e1357eefb8bdf1542850d66d8007d620e405...</code> (128 hex digits long).</td>
             </tr>
             <tr>
-                <td><code>blake2b</code></td>
+                <td><code>blake2b-512</code></td>
                 <td>Full-length form only, using the 2B variant (64 bit) as defined by [[!RFC7693]]. MUST be encoded
                     using hex (base16) encoding [[!RFC4648]]. For example, the <code>blake2b</code> digest of a
                     zero-length bitstream starts <code>786a02f742015903c6c6fd852552d272912f4740...</code> (128 hex

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -263,6 +263,15 @@
             An algorithmic characterization of the contents of a file conforming to a standard digest algorithm.
         </dd>
         <dt>
+            <dfn>Extension</dfn>:
+        </dt>
+        <dd>
+            Extensions are used to collaborate, review, and publish additional non-normative functions related to OCFL.
+            Extensions are intended to be informational and cite-able, but outside the scope of the normal specification
+            process. Existing extensions may be found in the <a href="https://ocfl.github.io/extensions/">OCFL
+            Extensions repository.</a>
+        </dd>
+        <dt>
             <dfn>Inventory</dfn>:
         </dt>
         <dd>
@@ -475,7 +484,7 @@
         <p>
             For storage of additional fixity values, and perhaps to support legacy content migration, implementers
             SHOULD choose from the following controlled vocabulary of digest algorithms. Additional algorithms MAY be
-            supplied using an extension mechanism, with no expectation that all clients will support them.
+            supplied using an <a>Extension</a> mechanism, with no expectation that all clients will support them.
         </p>
         <table class="simple" id="digest-algorithms">
             <thead>
@@ -581,7 +590,8 @@
                 <dt><code>digestAlgorithm</code></dt>
                 <dd>
                     The digest algorithm used for calculating digests within the OCFL Object. This SHOULD be
-                    <code>sha512</code>, however <code>sha256</code> MAY also be used.
+                    <code>sha512</code>, however <code>sha256</code> MAY also be used. See the
+                    <a href="#digest-algorithms">section on Digests</a> for more information.
                 </dd>
                 <dt><code>head</code></dt>
                 <dd>
@@ -736,9 +746,9 @@
             <p>
                 The <code>fixity</code> block SHOULD contain keys corresponding to the controlled vocabulary given in
                 the <a href="#digest-algorithms">digest algorithms</a> listed in the Digests section. Additional keys
-                MAY be used if they are supplied in an extension. The value of each key MUST follow the structure of
-                the <a href="#manifest"><code>manifest</code></a> block; that is, a key corresponding to the digest
-                value, and an array of <a>content path</a>s that match that digest.
+                MAY be used if they are supplied in an <a href="">extension</a>. The value of each key MUST follow the
+                structure of the <a href="#manifest"><code>manifest</code></a> block; that is, a key corresponding to
+                the digest value, and an array of <a>content path</a>s that match that digest.
             </p>
             <blockquote class="informative">
                 <p>

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -746,7 +746,7 @@
             <p>
                 The <code>fixity</code> block SHOULD contain keys corresponding to the controlled vocabulary given in
                 the <a href="#digest-algorithms">digest algorithms</a> listed in the Digests section. Additional keys
-                MAY be used if they are supplied in an <a href="">extension</a>. The value of each key MUST follow the
+                MAY be used if they are supplied in an <a>Extension</a>. The value of each key MUST follow the
                 structure of the <a href="#manifest"><code>manifest</code></a> block; that is, a key corresponding to
                 the digest value, and an array of <a>content path</a>s that match that digest.
             </p>

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -474,7 +474,8 @@
         </p>
         <p>
             For storage of additional fixity values, and perhaps to support legacy content migration, implementers
-            MAY choose from the following list of digest algorithms:
+            SHOULD choose from the following controlled vocabulary of digest algorithms. Additional algorithms MAY be
+            supplied using an extension mechanism, with no expectation that all clients will support them.
         </p>
         <table class="simple" id="digest-algorithms">
             <thead>
@@ -580,8 +581,7 @@
                 <dt><code>digestAlgorithm</code></dt>
                 <dd>
                     The digest algorithm used for calculating digests within the OCFL Object. This SHOULD be
-                    <code>sha512</code>, however other values are permitted. See the <a href="#digests">section on
-                    Digests</a> for more information.
+                    <code>sha512</code>, however <code>sha256</code> MAY also be used.
                 </dd>
                 <dt><code>head</code></dt>
                 <dd>
@@ -734,10 +734,11 @@
                 key of <code>fixity</code> within the inventory.
             </p>
             <p>
-                The <code>fixity</code> block MUST contain keys corresponding to <a href="#digest-algorithms">digest
-                algorithms listed in the Digests section</a>. The value of each key MUST follow the structure of the
-                <a href="#manifest"><code>manifest</code></a> block; that is, a key corresponding to the digest value,
-                and an array of <a>content path</a>s that match that digest.
+                The <code>fixity</code> block SHOULD contain keys corresponding to the controlled vocabulary given in
+                the <a href="#digest-algorithms">digest algorithms</a> listed in the Digests section. Additional keys
+                MAY be used if they are supplied in an extension. The value of each key MUST follow the structure of
+                the <a href="#manifest"><code>manifest</code></a> block; that is, a key corresponding to the digest
+                value, and an array of <a>content path</a>s that match that digest.
             </p>
             <blockquote class="informative">
                 <p>


### PR DESCRIPTION
This PR fixes some language about the intended use of the table of digest algorithms as a controlled vocabulary. 

Also clarifies the length of `blake2b` to be 512. 

Fixed #371 
Fixed #364 
Refs #292 