### PR TITLE
Expand on when it is OK to not have an inventory in a version directory.

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -794,12 +794,14 @@ DIGEST inventory.json
             SHOULD include an inventory file that is an <a href="#inventory">Inventory</a> of all content for versions
             up to and including that particular version. Where an OCFL Object contains <code>inventory.json</code>
             in version directories, the inventory file in the OCFL Object Root MUST be the same as the file in the
-            most recent version. Every inventory file MUST have a corresponding <a href="#inventory-digest">Inventory
-            Digest</a>.
+            most recent version, and that inventory file MUST NOT be subsequently deleted. Every inventory file MUST
+            have a corresponding <a href="#inventory-digest">Inventory Digest</a>.
         </p>
         <blockquote class="informative">
             Non-normative note: Storing an inventory for every version provides redundancy for this critical
-            information in a way that is compatible with storage strategies that have immutable version directories.
+            information, and allows reconstruction of prior versions when the most recent versions are not available.
+            The option to not store the inventory file in prior version directories is to facilitate migration from
+            other object structures that have immutable version directories.
         </blockquote>
     </section>
 

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -794,8 +794,8 @@ DIGEST inventory.json
             SHOULD include an inventory file that is an <a href="#inventory">Inventory</a> of all content for versions
             up to and including that particular version. Where an OCFL Object contains <code>inventory.json</code>
             in version directories, the inventory file in the OCFL Object Root MUST be the same as the file in the
-            most recent version, and that inventory file MUST NOT be subsequently deleted. Every inventory file MUST
-            have a corresponding <a href="#inventory-digest">Inventory Digest</a>.
+            most recent version directory, and that inventory file MUST NOT be subsequently deleted. Every inventory
+            file MUST have a corresponding <a href="#inventory-digest">Inventory Digest</a>.
         </p>
         <blockquote class="informative">
             Non-normative note: Storing an inventory for every version provides redundancy for this critical

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -794,8 +794,8 @@ DIGEST inventory.json
             SHOULD include an inventory file that is an <a href="#inventory">Inventory</a> of all content for versions
             up to and including that particular version. Where an OCFL Object contains <code>inventory.json</code>
             in version directories, the inventory file in the OCFL Object Root MUST be the same as the file in the
-            most recent version directory, and that inventory file MUST NOT be subsequently deleted. Every inventory
-            file MUST have a corresponding <a href="#inventory-digest">Inventory Digest</a>.
+            most recent version directory, and the inventory file in the version directory MUST NOT be subsequently
+            deleted. Every inventory file MUST have a corresponding <a href="#inventory-digest">Inventory Digest</a>.
         </p>
         <blockquote class="informative">
             Non-normative note: Storing an inventory for every version provides redundancy for this critical


### PR DESCRIPTION
This is to close the loophole where it is apparently OK to delete inventory files in prior versions, an unintentional consequence of the wording chosen to support migration from previous systems with immutable version directories.