### PR TITLE
Fixed: Update ocfl_layout.json spec

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -866,9 +866,9 @@ DIGEST inventory.json
         </p>
         <ul>
           <li>
-            <code>uri</code> - A URI identifying the precise arrangement of directories and OCFL objects under the
-            storage root, i.e. how OCFL object identifiers are mapped to directory hierarchies.
-            If a URL is used then it SHOULD resolve to a detailed specification of the arrangement.
+            <code>key</code> - A key identifying the precise arrangement of directories and OCFL objects under the
+            storage root, i.e. how OCFL object identifiers are mapped to directory hierarchies. The value of this key
+            is not defined in the OCFL specification, but MUST correspond to a value given in an <a>Extension</a>.
           </li>
           <li>
             <code>description</code> - A human readable description of the arrangement of directories and OCFL


### PR DESCRIPTION
As a result of discussions around how extensions are to be referenced in the spec, it was decided to change the value of the key in the ocfl_layout.json file from a URI to a string value provided in an extension.