### PR TITLE
Talk only about content paths for forward slash

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -576,10 +576,9 @@
             files has no significance.
         </p>
         <p>
-            The forward slash (/) path separator MUST be used in content and logical paths in the
-            <a href="#manifest">manifest</a>, <a href="#fixity">fixity</a>, and <a href="#version">state</a> blocks
-            within the inventory. Implementations that target systems using other separators will need to translate
-            paths appropriately.
+            The forward slash (/) path separator MUST be used in content paths in the <a href="#manifest">manifest</a>
+            and <a href="#fixity">fixity</a> blocks within the inventory. Implementations that target systems using
+            other separators will need to translate paths appropriately.
         </p>
         <blockquote class="informative">
             <p>


### PR DESCRIPTION
In section 3.5 second para, note that the forward slash part refers only to content paths.

cf. #407 and https://github.com/OCFL/spec/wiki/2019.12.03-Editors-Meeting