### PR TITLE
Fixed: Logical paths clarification

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -296,7 +296,8 @@
         </dt>
         <dd>
             A path that represents a file's location in the <a>logical state</a> of an object. Logical paths are
-            used in conjunction with a digest to represent the file name for a given bitstream at a given version.
+            used in conjunction with a digest to represent the file name and path for a given bitstream at a given
+            version.
         </dd>
         <dt>
             <dfn>Logical State</dfn>:
@@ -696,7 +697,8 @@
                             are digest values, each of which MUST correspond to an entry in the
                             <a href="#manifest">manifest of the inventory</a>. The value for each key is an array
                             containing <a>logical path</a> names of files in the OCFL Object state that have
-                            content with the given digest.
+                            content with the given digest. Logical paths MUST NOT start with <code>.</code>,
+                            <code>..</code>, <code>/</code>, or <code>//</code>.
                         </p>
                         <blockquote class="informative">
                             <p>

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -702,7 +702,7 @@
                         <p>
                             <a href="#logical-path">Logical paths</a> present the structure of an OCFL Object at a
                             given version. This is given as an array of file paths, with the following restrictions
-                            provide for path safety in this common case. The logical path SHOULD be interpreted as a
+                            provide for path safety in this common case. The logical path MUST be interpreted as a
                             set of one or more path elements joined by a <code>/</code> path separator. Path elements
                             MUST NOT be <code>.</code>, <code>..</code>, or empty (<code>//</code>). Additionally,
                             a logical path MUST NOT begin with a leading <code>/</code>.

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -697,8 +697,15 @@
                             are digest values, each of which MUST correspond to an entry in the
                             <a href="#manifest">manifest of the inventory</a>. The value for each key is an array
                             containing <a>logical path</a> names of files in the OCFL Object state that have
-                            content with the given digest. Logical paths MUST NOT start with <code>.</code>,
-                            <code>..</code>, <code>/</code>, or <code>//</code>.
+                            content with the given digest.
+                        </p>
+                        <p>
+                            <a href="#logical-path">Logical paths</a> present the structure of an OCFL Object at a
+                            given version. This is given as an array of file paths, with the following restrictions
+                            provide for path safety in this common case. The logical path SHOULD be interpreted as a
+                            set of one or more path elements joined by a <code>/</code> path separator. Path elements
+                            MUST NOT be <code>.</code>, <code>..</code>, or empty (<code>//</code>). Additionally,
+                            a logical path MUST NOT begin with a leading <code>/</code>.
                         </p>
                         <blockquote class="informative">
                             <p>

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -701,11 +701,12 @@
                         </p>
                         <p>
                             <a href="#logical-path">Logical paths</a> present the structure of an OCFL Object at a
-                            given version. This is given as an array of file paths, with the following restrictions
-                            provide for path safety in this common case. The logical path MUST be interpreted as a
-                            set of one or more path elements joined by a <code>/</code> path separator. Path elements
-                            MUST NOT be <code>.</code>, <code>..</code>, or empty (<code>//</code>). Additionally,
-                            a logical path MUST NOT begin with a leading <code>/</code>.
+                            given version. This is given as an array of values, with the following restrictions to
+                            provide for path safety in the common case of the logical path value representing a file
+                            path. The logical path MUST be interpreted as a set of one or more path elements joined by
+                            a <code>/</code> path separator. Path elements MUST NOT be <code>.</code>, <code>..</code>,
+                            or empty (<code>//</code>). Additionally, a logical path MUST NOT begin with a leading
+                            <code>/</code>.
                         </p>
                         <blockquote class="informative">
                             <p>


### PR DESCRIPTION
Clarify that logical paths must not start with reserved characters. Also adds 'and path' in the definition of logical paths.

Fixes #411 
Fixes #413 