### PR TITLE
`address` SHOULD be a URI

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -750,8 +750,8 @@
                         SHOULD contain an address key, <code>address</code>.
                         The <code>name</code> value is any readable name of the user, e.g., a proper name, user ID,
                         agent ID.
-                        The <code>address</code> value is either a mailto URI [[RFC6068]] with the e-mail address of
-                        the <code>user</code> or a URL to a personal identifier, e.g., an ORCID iD.
+                        The <code>address</code> value SHOULD be a URI: either a mailto URI [[RFC6068]] with the e-mail
+                        address of the user or a URL to a personal identifier, e.g., an ORCID iD.
                     </dd>
                 </dl>
             </section>


### PR DESCRIPTION
Fixes #422 

Note that this PR removes code font from user in the sentence to match the use of regular text user in the rest of the paragraph when we are not referring to the JSON jkey.