### PR TITLE
Minor HTML tidy and fixes

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <title>Oxford Common File Layout Specification</title>
-    <meta charset="utf-8">
-    <meta name="description" content="Oxford Common File Layout Specification">
+    <meta charset="utf-8"></meta>
+    <meta name="description" content="Oxford Common File Layout Specification"></meta>
     <script src="../respec-w3c-common.js"
             async class="remove"></script>
     <script class="remove">
@@ -328,7 +328,7 @@
         </dd>
         <dt>
             <dfn>OCFL Object Root</dfn>:
-        <dt>
+        </dt>
         <dd>
             The base directory of an <a>OCFL Object</a>, identified by a [[NAMASTE]] file "0=ocfl_object_1.0".
         </dd>
@@ -340,7 +340,7 @@
         </dd>
         <dt>
             <dfn>OCFL Version</dfn>:
-        <dt>
+        </dt>
         <dd>
             The state of an <a>OCFL Object</a>'s content which is constructed using the incremental changes recorded in
             the sequence of corresponding and prior version directories.

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
     <title>Oxford Common File Layout Specification</title>
-    <meta charset="utf-8"></meta>
-    <meta name="description" content="Oxford Common File Layout Specification"></meta>
+    <meta charset="utf-8"/>
+    <meta name="description" content="Oxford Common File Layout Specification"/>
     <script src="../respec-w3c-common.js"
             async class="remove"></script>
     <script class="remove">


### PR DESCRIPTION
While looking for the travis error in #428 I found two erroneous `<dt>` that should be `</dt>` and also note that adding closing `</meta>` makes it easier to use an XML checker 