### PR TITLE
Add link to extension in terminology, to mirror new text for storage root extensions

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -936,7 +936,7 @@ DIGEST inventory.json
             of extending the functionality of an OCFL Object. The <code>extensions</code> directory
             <span id="E067">MUST NOT</span> contain any files, and no sub-directories other than extension
             sub-directories. Extension sub-directories <span id="W013">SHOULD</span> be named according to a registered
-            extension name. The specific structure and function of the extension, as well as a declaration of the
+            <a>extension</a> name. The specific structure and function of the extension, as well as a declaration of the
             registered extension name <span id="E068">MUST</span> be defined in one of the following locations:
         </p>
         <ul>


### PR DESCRIPTION
To mirror link added in #483. Editorial, no change to meaning

"registered [extension](https://ocfl.io/draft/spec/#dfn-extension) name"