### PR TITLE
Add date and links to implementation notes

### DIFF
--- a/1.0/implementation-notes/index.html
+++ b/1.0/implementation-notes/index.html
@@ -8,8 +8,11 @@
             async class="remove"></script>
     <script class="remove">
         var respecConfig = {
+            publishDate: "2020-07-07",
             specStatus: "NOTE",
             shortName: "ocfl-impl",
+            thisVersion: "https://ocfl.io/1.0/implementation-notes/",
+            latestVersion: "https://ocfl.io/latest/implementation-notes/",
             lint: {
                 // turn off w3c-specific linting
                 "privsec-section": false,


### PR DESCRIPTION
Merge this into `release-1.0` before merging #491

I do wonder whether we should use `specStatus: "REC"` for the implementation notes instead of `"NOTE"` which then says this is a  "Working Group Note 07 July 2020" which simply isn't true. However, I haven't changed that