### PR TITLE
Fixed: Make travis.ci use the minimal image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-language: java
-jdk:
-  - oraclejdk9
+language: minimal
 
 install:
  - pip install --user html5validator beautifulsoup4 jsonschema


### PR DESCRIPTION
The Travis build did not need to install the whole JDK, which would sometimes cause builds to fail.

This PR changes the travis config to use the minimal image, which should be enough to run what we need.