### PR TITLE
link directly to press release; create line break between names

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ Specifically, the benefits of the OCFL include:
   * __Storage diversity__, to ensure content can be stored on diverse storage infrastructures including conventional filesystems and cloud object stores
 
 ## News
-  * [Version 1.0 Release Announcement](/news/)
+  * [Version 1.0 Release Announcement](/news/#version-10-of-the-oxford-common-file-layout-ocfl-released)
 
 ## Latest Release (1.0)
   * [OCFL Specification](1.0/spec/)

--- a/news/index.md
+++ b/news/index.md
@@ -57,9 +57,9 @@ which also contains links to the Slack channel and mailing lists.
 
 ### The OCFL Editors
 
-Andrew Hankinson (Bodleian Libraries, University of Oxford)
-Neil Jefferies (Bodleian Libraries, University of Oxford)
-Rosalyn Metz (Emory University)
-Julian Morley (Stanford University)
-Simeon Warner (Cornell University)
+Andrew Hankinson (Bodleian Libraries, University of Oxford)  
+Neil Jefferies (Bodleian Libraries, University of Oxford)  
+Rosalyn Metz (Emory University)  
+Julian Morley (Stanford University)  
+Simeon Warner (Cornell University)  
 Andrew Woods (LYRASIS)

--- a/news/index.md
+++ b/news/index.md
@@ -57,9 +57,9 @@ which also contains links to the Slack channel and mailing lists.
 
 ### The OCFL Editors
 
-Andrew Hankinson (Bodleian Libraries, University of Oxford)  
-Neil Jefferies (Bodleian Libraries, University of Oxford)  
-Rosalyn Metz (Emory University)  
-Julian Morley (Stanford University)  
-Simeon Warner (Cornell University)  
+Andrew Hankinson (Bodleian Libraries, University of Oxford)\
+Neil Jefferies (Bodleian Libraries, University of Oxford)\
+Rosalyn Metz (Emory University)\
+Julian Morley (Stanford University)\
+Simeon Warner (Cornell University)\
 Andrew Woods (LYRASIS)


### PR DESCRIPTION
a change that doesn't need to happen for 1.0.

note that a double space creates a linebreak