### PR TITLE
Fix examples in spec

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -1304,6 +1304,10 @@ DIGEST inventory.json
       "state": {
         "7545b8...f67": [ "a file.wxy" ],
         "af318d...3cd": [ "another file.xyz" ]
+      },
+      "user": {
+        "address": "mailto:admin@example.org",
+        "name": "Some Admin"
       }
     }
   }

--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -1155,7 +1155,7 @@ DIGEST inventory.json
         "7545b8...f67": [ "file.txt" ]
       },
       "user": {
-        "address": "alice@example.org",
+        "address": "mailto:alice@example.org",
         "name": "Alice"
       }
     }
@@ -1240,7 +1240,7 @@ DIGEST inventory.json
         "ffccf6...62e": [ "image.tiff" ]
       },
       "user": {
-        "address": "alice@example.com",
+        "address": "mailto:alice@example.com",
         "name": "Alice"
       }
     },
@@ -1252,7 +1252,7 @@ DIGEST inventory.json
         "cf83e1...a3e": [ "empty.txt", "empty2.txt" ]
       },
       "user": {
-        "address": "bob@example.com",
+        "address": "mailto:bob@example.com",
         "name": "Bob"
       }
     },
@@ -1265,7 +1265,7 @@ DIGEST inventory.json
         "ffccf6...62e": [ "image.tiff" ]
       },
       "user": {
-        "address": "cecilia@example.com",
+        "address": "mailto:cecilia@example.com",
         "name": "Cecilia"
       }
     }
@@ -1417,7 +1417,7 @@ myfirstbag
         "f15428...83f": [ "myfirstbag/manifest-md5.txt" ]
       },
       "user": {
-        "address": "someone@example.org",
+        "address": "mailto:someone@example.org",
         "name": "Some One"
       }
     },
@@ -1433,7 +1433,7 @@ myfirstbag
         "b8bdf1...927": [ "myfirstbag/data/27614-h/images/q173.txt" ]
       },
       "user": {
-        "address": "somebody-else@example.org",
+        "address": "mailto:somebody-else@example.org",
         "name": "Somebody Else"
       }
     }


### PR DESCRIPTION
- Add 'mailto' to examples in spec
- Add 'user' block in example where it was previously missing

In order to resolve issue-539, the Moab example must additionally be fixed such that version numbers match across the version directory names, the 'head' property in the inventory, the version keys in the versions block of the inventory and the paths in the 'manifest' block of the inventory. 

Partial resolution to https://github.com/OCFL/spec/issues/539