### PR TITLE
Add formerEditor: Andrew Hankinson

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -43,6 +43,16 @@
                     companyURL: "https://library.harvard.edu/"
                 }
             ],
+            formerEditors: [
+              {
+                name: "Andrew Hankinson",
+                company: "RISM Digital Center",
+                companyURL: "https://rism.digital/",
+                orcid: "0000-0003-2663-0003",
+                w3cid: "81527",
+                retiredDate: "2020-08-31",
+              },
+            ],
             edDraftURI: "https://ocfl.io/draft/spec/",
             wg: "Oxford Common File Layout Editors",
             wgURI: "https://ocfl.io",


### PR DESCRIPTION
This PR needs additional modification to render. According to the [documentation](https://respec.org/docs/#formerEditors), it should work.

The non-rendering issue appears to be related to our modified [respec-w3c-common.js](https://github.com/OCFL/spec/blob/main/draft/respec-w3c-common.js). The `formerEditors` block correctly renders when replacing the [script](https://github.com/OCFL/spec/blob/main/draft/spec/index.html#L7) with:
```
    <script src="https://www.w3.org/Tools/respec/respec-w3c"
```