### PR TITLE
Fix missing para in blockquote

### DIFF
--- a/draft/spec/index.html
+++ b/draft/spec/index.html
@@ -927,8 +927,10 @@ DIGEST inventory.json
             in the corresponding <code>version</code> block in the current inventory file.
         </p>
         <blockquote class="informative">
-            Non-normative note: Storing an inventory for every version provides redundancy for this critical
-            information in a way that is compatible with storage strategies that have immutable version directories.
+	    <p>
+              Non-normative note: Storing an inventory for every version provides redundancy for this critical
+              information in a way that is compatible with storage strategies that have immutable version directories.
+	    </p>
         </blockquote>
         <section id="conformance-of-prior-versions">
           <h2>Conformance of prior versions</h2>


### PR DESCRIPTION
Trivial fix for inconsistency that is messing up work on #554. Text inside a blockquote section should also be inside a p.  No change to content (or rendering even).