### PR TITLE
Add Andrew Hankinson as former editor

### DIFF
--- a/draft/spec/index.md
+++ b/draft/spec/index.md
@@ -17,13 +17,17 @@ Latest editor's draft: <https://ocfl.io/draft/spec/>
 * [Simeon Warner](https://orcid.org/0000-0002-7970-7855), [Cornell University](https://www.library.cornell.edu/)
 * [Andrew Woods](https://orcid.org/0000-0002-8318-4225), [Harvard University](https://library.harvard.edu/)
 
+**Former Editors:**
+
+* [Andrew Hankinson](https://orcid.org/0000-0003-2663-0003)
+
 **Additional Documents:**
 
 * [Implementation Notes](https://ocfl.io/draft/implementation-notes/)
 * [Validation Codes](https://ocfl.io/draft/spec/validation-codes.html)
 * [Extensions](https://github.com/OCFL/extensions/)
 
-**Previous version:**
+**Previous Version:**
 * <https://ocfl.io/1.0/spec/>
 
 **Repository:**


### PR DESCRIPTION
FIxes #599

I don't think it makes sense to add a former editor's current affiliation because that institution had nothing to do with the spec. I have not put any affiliation on the grounds that the ORCID link is enough to disambiguate the person and one can look at past specs to see the affiliation at the time they were published.