### PR TITLE
Replicate specification of Object extension section

### DIFF
--- a/draft/spec/index.md
+++ b/draft/spec/index.md
@@ -717,9 +717,17 @@ either a directory hierarchy of OCFL Objects or top-level OCFL Objects
 The behavior of the storage root may be extended to support features from other specifications.
 
 The base directory of an OCFL Storage Root <span class="rfc2119">MAY</span> contain a directory named `extensions` for
-the purposes of extending the functionality of an OCFL Storage Root. The storage root `extensions` directory <span
-id="E086" class="rfc2119">MUST</span> conform to the same guidelines and limitations as those defined for [object
-extensions](#object-extensions).
+the purposes of extending the functionality of an OCFL Storage Root. The guidelines and limitations for the storage
+root `extensions` directory are defined in alignment with those of the [object extensions](#object-extensions).
+
+The `extensions` directory <span id="E112" class="rfc2119">MUST NOT</span> contain any files, and no sub-directories
+other than extension sub-directories. Extension sub-directories <span id="W016" class="rfc2119">SHOULD</span> be named
+according to a <a>registered extension name</a>.
+
+> Non-normative note: Extension sub-directories should use the same name as a registered extension in order to both
+avoid the possiblity of an extension sub-directory colliding with the name of another registered extension as well as to
+facilitate the recognition of extensions by OCFL clients. See also [Documenting Local
+Extensions](#documenting-local-extensions).
 
 > Non-normative note: Storage extensions can be used to support additional features, such as providing the storage
 hierarchy disposition when pairtree is in use, or additional human-readable text about the nature of the storage root.

--- a/draft/spec/index.md
+++ b/draft/spec/index.md
@@ -613,7 +613,7 @@ only store a log entry if an intervention was required.
 
 The base directory of an OCFL Object <span class="rfc2119">MAY</span> contain a directory named `extensions` for the
 purposes of extending the functionality of an OCFL Object. The `extensions` directory <span id="E067"
-class="rfc2119">MUST NOT</span> contain any files, and no sub-directories other than extension sub-directories.
+class="rfc2119">MUST NOT</span> contain any files or sub-directories other than extension sub-directories.
 Extension sub-directories <span id="W013" class="rfc2119">SHOULD</span> be named according to a [registered extension
 name](#dfn-registered-extension-name) in the [OCFL Extensions repository](https://ocfl.github.io/extensions/).
 
@@ -720,16 +720,16 @@ The base directory of an OCFL Storage Root <span class="rfc2119">MAY</span> cont
 the purposes of extending the functionality of an OCFL Storage Root. The guidelines and limitations for the storage
 root `extensions` directory are defined in alignment with those of the [object extensions](#object-extensions).
 
-The `extensions` directory <span id="E112" class="rfc2119">MUST NOT</span> contain any files, and no sub-directories
+The `extensions` directory <span id="E112" class="rfc2119">MUST NOT</span> contain any files or sub-directories
 other than extension sub-directories. Extension sub-directories <span id="W016" class="rfc2119">SHOULD</span> be named
 according to a <a>registered extension name</a>.
 
-> Non-normative note: Extension sub-directories should use the same name as a registered extension in order to both
+> Non-normative notes: Extension sub-directories should use the same name as a registered extension in order to both
 avoid the possiblity of an extension sub-directory colliding with the name of another registered extension as well as to
 facilitate the recognition of extensions by OCFL clients. See also [Documenting Local
 Extensions](#documenting-local-extensions).
-
-> Non-normative note: Storage extensions can be used to support additional features, such as providing the storage
+>
+> Storage extensions can be used to support additional features, such as providing the storage
 hierarchy disposition when pairtree is in use, or additional human-readable text about the nature of the storage root.
 
 ### 4.5 Documenting Local Extensions

--- a/draft/spec/validation-codes.md
+++ b/draft/spec/validation-codes.md
@@ -94,7 +94,6 @@
 | E083 | 'There MUST be a deterministic mapping from an object identifier to a unique storage path.' | https://ocfl.io/draft/spec/#E083
 | E084 | 'Storage hierarchies MUST NOT include files within intermediate directories.' | https://ocfl.io/draft/spec/#E084
 | E085 | 'Storage hierarchies MUST be terminated by OCFL Object Roots.' | https://ocfl.io/draft/spec/#E085
-| E086 | 'The storage root extensions directory MUST conform to the same guidelines and limitations as those defined for object extensions.' | https://ocfl.io/draft/spec/#E086
 | E087 | 'An OCFL validator MUST ignore any files in the storage root it does not understand.' | https://ocfl.io/draft/spec/#E087
 | E088 | 'An OCFL Storage Root MUST NOT contain directories or sub-directories other than as a directory hierarchy used to store OCFL Objects or for storage root extensions.' | https://ocfl.io/draft/spec/#E088
 | E089 | 'If the preservation of non-OCFL-compliant features is required then the content MUST be wrapped in a suitable disk or filesystem image format which OCFL can treat as a regular file.' | https://ocfl.io/draft/spec/#E089
@@ -119,6 +118,8 @@
 | E108 | 'The contentDirectory value MUST represent a direct child directory of the version directory in which it is found.' | https://ocfl.io/draft/spec/#E108
 | E110 | 'A unique identifier for the OCFL Object MUST NOT change between versions of the same object.' | https://ocfl.io/draft/spec/#E110
 | E111 | 'If present, [the value of the fixity key] MUST be a JSON object, which may be empty.' | https://ocfl.io/draft/spec/#E111
+| E112 | 'The extensions directory must not contain any files, and no sub-directories other than extension sub-directories.' | https://ocfl.io/draft/spec/#E112
+
 
 ## Warnings (corresponding with SHOULD in specification)
 
@@ -138,3 +139,4 @@
 | W013 | 'In an OCFL Object, extension sub-directories SHOULD be named according to a registered extension name.' | https://ocfl.io/draft/spec/#W013
 | W014 | 'Storage hierarchies within the same OCFL Storage Root SHOULD use just one layout pattern.' | https://ocfl.io/draft/spec/#W014
 | W015 | 'Storage hierarchies within the same OCFL Storage Root SHOULD consistently use either a directory hierarchy of OCFL Objects or top-level OCFL Objects.' | https://ocfl.io/draft/spec/#W015
+| W016 | 'In the Storage Root, extension sub-directories SHOULD be named according to a registered extension name.' | https://ocfl.io/draft/spec/#W016

--- a/draft/spec/validation-codes.md
+++ b/draft/spec/validation-codes.md
@@ -76,7 +76,7 @@
 | E063 | 'Every OCFL Object must have an inventory file within the OCFL Object Root, corresponding to the state of the OCFL Object at the current version.' | https://ocfl.io/draft/spec/#E063
 | E064 | 'Where an OCFL Object contains inventory.json in version directories, the inventory file in the OCFL Object Root must be the same as the file in the most recent version.' | https://ocfl.io/draft/spec/#E064
 | E066 | 'Each version block in each prior inventory file must represent the same object state as the corresponding version block in the current inventory file.' | https://ocfl.io/draft/spec/#E066
-| E067 | 'The extensions directory must not contain any files, and no sub-directories other than extension sub-directories.' | https://ocfl.io/draft/spec/#E067
+| E067 | 'The extensions directory must not contain any files or no sub-directories other than extension sub-directories.' | https://ocfl.io/draft/spec/#E067
 | E069 | 'An OCFL Storage Root MUST contain a Root Conformance Declaration identifying it as such.' | https://ocfl.io/draft/spec/#E069
 | E070 | 'If present, [the ocfl_layout.json document] MUST include the following two keys in the root JSON object: [extension, description]' | https://ocfl.io/draft/spec/#E070
 | E071 | 'The value of the [ocfl_layout.json] extension key must be the registered extension name for the extension defining the arrangement under the storage root.' | https://ocfl.io/draft/spec/#E071
@@ -118,7 +118,7 @@
 | E108 | 'The contentDirectory value MUST represent a direct child directory of the version directory in which it is found.' | https://ocfl.io/draft/spec/#E108
 | E110 | 'A unique identifier for the OCFL Object MUST NOT change between versions of the same object.' | https://ocfl.io/draft/spec/#E110
 | E111 | 'If present, [the value of the fixity key] MUST be a JSON object, which may be empty.' | https://ocfl.io/draft/spec/#E111
-| E112 | 'The extensions directory must not contain any files, and no sub-directories other than extension sub-directories.' | https://ocfl.io/draft/spec/#E112
+| E112 | 'The extensions directory must not contain any files or sub-directories other than extension sub-directories.' | https://ocfl.io/draft/spec/#E112
 
 
 ## Warnings (corresponding with SHOULD in specification)


### PR DESCRIPTION
This update replicates the Object extension specification text from Object extension into Storage Root extension

Resolves: #557

Supersedes: https://github.com/OCFL/spec/pull/583