### PR TITLE
Link to adopted extensions

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,9 +22,9 @@ Specifically, the benefits of the OCFL include:
 
 ## Tools
 
-  * [OCFL Implementations](https://github.com/OCFL/spec/wiki/Implementations)
-  * [OCFL Community Extensions](https://github.com/OCFL/extensions)
-  * [OCFL Fixture Objects](https://github.com/OCFL/fixtures)
+* [OCFL Community Extensions](https://ocfl.github.io/extensions/)
+* [OCFL Implementations](https://github.com/OCFL/spec/wiki/Implementations)
+* [OCFL Fixture Objects](https://github.com/OCFL/fixtures)
 
 ## Previous Releases
 


### PR DESCRIPTION
We currently link to the repository from the homepage, I think we should instead link to the adopted extensions. That page should then probably have a link to the repo for "extensions under consideration" too (see https://github.com/OCFL/extensions/issues/60)