### PR TITLE
Update .travis.yml to test .md instead of previous .html files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
 
 script:
  - html5validator --ignore "Section lacks heading" --blacklist _layouts
- - test `cut -c121- draft/spec/index.html | grep -vx "^$" | wc -l` -eq 0
- - test `cut -c121- draft/implementation-notes/index.html | grep -vx "^$" | wc -l` -eq 0
+ - test `cut -c121- draft/spec/index.md | grep -vx "^$" | wc -l` -eq 0
+ - test `cut -c121- draft/implementation-notes/index.md | grep -vx "^$" | wc -l` -eq 0
  - python scripts/check_examples.py


### PR DESCRIPTION
It appears that Travis is no longer active for the OCFL spec. We should likely migrate to GH Actions.

![image](https://github.com/OCFL/spec/assets/149283/939ee729-efbf-47b4-9b63-07c3ee105a14)
