### PR TITLE
clarify what metadata and content means

### DIFF
--- a/draft/spec/index.md
+++ b/draft/spec/index.md
@@ -69,7 +69,8 @@ versioning, robustness, and storage diversity.
 #### Completeness
 {:.no_toc #completeness}
 
-The OCFL recommends storing metadata and the content it describes together so the OCFL object can be fully understood in
+The OCFL recommends storing metadata (this includes all types of metadata; e.g., technical, structural, descriptive, etc.) 
+and the content (e.g., images, text files, etc.) it describes together so the OCFL object can be fully understood in
 the absence of original software. The OCFL does not make recommendations about what constitutes an object, nor does it
 assume what type of metadata is needed to fully understand the object, recognizing those decisions may differ from one
 repository to another. However, it is recommended that when making this decision, implementers consider what is


### PR DESCRIPTION
We’ve found that institutions often assume OCFL is opinionated about the internal structure of an object, despite the introduction stating explicitly that OCFL does not define an object’s structure (i.e., what makes an object an object).

One reason for this misunderstanding may be our loose use of the terms’ metadata’ and ‘content’ in the introduction (I’ll take the blame for that). In practice, when people see “metadata,” they often think only of descriptive metadata. However, metadata can also refer to other types, such as METS, which encompasses both structural and administrative metadata, or MIX, which captures technical metadata about an image.

The changes here aim to clarify that we mean all forms of metadata, not just descriptive, so that users better understand OCFL’s scope.